### PR TITLE
Use HTTPS for youtube link

### DIFF
--- a/pages/videos.html
+++ b/pages/videos.html
@@ -9,7 +9,7 @@ permalink: /videos/
     <a href='{{ site.baseurl }}{{ video.url }}'>
       <h3>{{ video.title }}</h3>
       <time>{{ video.date | date: '%d %B %Y'}}</time>
-      <img src='http://img.youtube.com/vi/{{ video.youtube_id }}/hqdefault.jpg' />
+      <img src='https://img.youtube.com/vi/{{ video.youtube_id }}/hqdefault.jpg' />
     </a>
     {% if video.tags != empty %}
       {% for tag in video.tags %}
@@ -19,4 +19,3 @@ permalink: /videos/
   </li>
   {% endfor %}
 </ul>
-


### PR DESCRIPTION
This PR solves the issue of mixed content and should make sure the video is not blocked by the browser.

`Mixed Content: The page at 'https://meetupgemist.nl/2020-04-24-Dutch-Kubernetes-Meetup/' was loaded over HTTPS, but requested an insecure frame 'http://www.youtube.com/embed/DUwS8k-5U10'. This request has been blocked; the content must be served over HTTPS.`